### PR TITLE
Bug_Fix: kubeconfig flag is being redefined

### DIFF
--- a/demo/pg_create.go
+++ b/demo/pg_create.go
@@ -436,6 +436,7 @@ func GetKubernetesConfigPath() string {
 		Print("Kubernetes configuration is set by the $KUBECONFIG env variable.")
 	} else if home := homedir.HomeDir(); home != "" {
 		Print("Kubernetes configuration is set by $HOME/.kube/config.")
+		flag.CommandLine = flag.NewFlagSet("kubeconfig", flag.ExitOnError)
 		kubeconfig = *flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
 	} else {
 		Print("Kubernetes configuration is set by config flag.")


### PR DESCRIPTION
This PR fixes #1 issue by removing and re-creating `kubeconfig`  flag if it already exists and  

Source:
https://github.com/vitessio/vitess/issues/10714#issuecomment-1186579881