### PR TITLE
Fix typo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -173,8 +173,7 @@ The generated YAML specification will be stored in the `usermanifests` but `kube
 
 The command:
 
-    a9s create pg instance --api-version v1beta3 --name my-pg --namespace default --replicas 3 --req
-uests-cpu 200m --limits-memory 200Mi --service-version 14 --volume-size 2Gi
+    a9s create pg instance --api-version v1beta3 --name my-pg --namespace default --replicas 3 --requests-cpu 200m --limits-memory 200Mi --service-version 14 --volume-size 2Gi
 
 Will generate a YAML spec called `usermanifests/my-pg-instance.yaml` with the following content:
 


### PR DESCRIPTION
This PR fixes a typo in a cmd at [Creating a Custom PostgreSQL Service Instance](https://github.com/anynines/a9s-cli-v2/commit/2756956b1337ca6bec3df291dd531c55e90036e4#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031R176-R177)