### PR TITLE
Add Goreleaser configuration to automate releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@
 #
 # Recommended: Go.AllowList.gitignore
 
-# Ignore everything
-*
-
 # But not these files...
 !/.gitignore
 
@@ -32,3 +29,5 @@ bin/a9s
 
 # ...even if they are in subdirectories
 !*/
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,51 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    main: ./main.go
+    binary: a9s
+    ldflags:
+      - -s -w
+      - -X 'github.com/anynines/a9s-cli-v2/cmd.BuildTimestamp={{ .Date }}'
+      - -X 'github.com/anynines/a9s-cli-v2/cmd.CliVersion={{ .Version }}'
+      - -X 'github.com/anynines/a9s-cli-v2/cmd.LastCommit={{ .Commit }}'
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"


### PR DESCRIPTION
I’ve added a PR to streamline our release process by integrating GoReleaser. This tool eliminates the need to maintain custom build scripts for releasing our CLI tool. GoReleaser is widely used by popular Go CLI projects like Ko, fzf, and GPTScript, making it a solid choice.

GoReleaser allows us to build, archive, package, sign, and publish artifacts to GitHub with ease. While our CI pipeline isn’t set up yet, GoReleaser integrates seamlessly with GitHub Actions, allowing us to trigger releases automatically on new tags.