### PR TITLE
A8s 2537 automate cli releases using goreleaser and GitHub actions

### DIFF
--- a/.github/workflows/releasing.yaml
+++ b/.github/workflows/releasing.yaml
@@ -1,0 +1,30 @@
+name: Create CLI release
+on:
+  push: # only triggers workflow when filter is satisfied
+    tags:
+      - 'v**'
+
+permissions:
+  contents: write # needed to write the binary archives to GitHub
+
+jobs:
+  create_release:
+      runs-on: ubuntu-22.04
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+            fetch-depth: 0 # necessary according to the goreleaser documentation
+        - name: Set up Go
+          uses: actions/setup-go@v5
+          with:
+            go-version: stable
+        - name: Run GoReleaser
+          uses: goreleaser/goreleaser-action@v6
+          with:
+            # either 'goreleaser' (default) or 'goreleaser-pro'
+            distribution: goreleaser
+            version: "~> v2"
+            args: release
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Development.md
+++ b/Development.md
@@ -52,7 +52,8 @@ Then execute:
 
 **Note**: The version of the a9s CLI is maintained in the file `VERSION` and used in the `Makefile` and passed via `ldflags` into the binary. Therefore, when issuing new releases the `VERSION` file needs to be updated before building the binaries.
 
-## Making Release
+## Making Release 
+>**Note:** this part is deprecated, please use the steps shown further below using the Goreleaser GitHub action
 
 Example: Release `v0.10.0`.
 
@@ -71,52 +72,53 @@ Example: Release `v0.10.0`.
 1. Update and upload the `releases.json` file to the S3 bucket.
 1. Deploy the documentation 
 
-## GitHub Release with GoReleaser
+## GitHub Release with GoReleaser and GitHub Actions
 
-This section contains targets for creating GitHub releases using GoReleaser.
+This section contains targets for creating GitHub releases using GoReleaser and GitHub actions.
 GoReleaser automates the build, packaging and release process for Go projects,
 integrating with GitHub's release functionality.
 
-> **Note:** This approach is intended for providing releases to end users and
-> exists in parallel with our current release process. It will be maintained
-> alongside the existing approach until we decide to fully implement the
-> release process with GitHub and GitHub Actions.
+### Creating GitHub Releases with GoReleaser and GitHub Actions
 
-### Creating GitHub Releases with GoReleaser
-
-This guide outlines the process for creating GitHub releases using GoReleaser.
+This guide outlines the process for creating GitHub releases using GoReleaser and GitHub actions.
 Following these steps will automate the build, packaging, and release process
 for your Go project, streamlining the creation of consistent and professional
 releases on GitHub.
 
-#### Prerequisites
-
-1. Install [GoReleaser](https://goreleaser.com/).
-2. Set up a GitHub Personal Access Token with appropriate permissions.
-
 #### Steps to Create a Release
 
-1. Set your GitHub token as an environment variable:
+Example: Release `v0.10.0`.
+
+1. Ensure that all tests are run including `e2e-tests`.
+1. Ensure that the documentation is updated incl. 
+    1. adding a copy of the docs to the corresponding version directory under `docs/versioned_docs`
+    2. updating `docs/versions.json` by adding the new version to the array
+1. Ensure the Readme is updated.
+1. Ensure the Changelog is updated.
+1. Ensure the remote `main` branch is up to date and clean with all necessary changes comitted.
+1. Ensure that your local main branch has the same state as the remote branch (i.e. it is up to date).
+1. Add the git tag to your local main branch:
 
     ```bash
-    export GITHUB_TOKEN="your_personal_access_token_here"
+    git tag -a v0.10.0 -m "Release v0.10.0"
     ```
-
-2. Add a git tag to the main branch:
+1. Push the tag to the remote main branch (this will trigger the GitHub action and start Goreleaser):
 
     ```bash
-    git tag -a v1.0.0 -m "Release v1.0.0"
+    git push origin v0.10.0
     ```
-
-3. Run GoReleaser:
-
-    ```bash
-    goreleaser release
-    ```
+1. Deploy the documentation 
 
 #### Testing the Release Process
 
-To test the release process without creating an actual release, use:
+To test the release process without creating an actual release, use goreleaser locally like this:
+
+1. Install [GoReleaser](https://goreleaser.com/). 
+2. Set up a GitHub Personal Access Token with appropriate permissions.
+3. Run the following two commands:
+```bash
+export GITHUB_TOKEN="your_personal_access_token_here"
+```
 
 ```bash
 goreleaser release --snapshot --clean


### PR DESCRIPTION
This adds the ability to use a new GitHub action to automate a release using Goreleaser and updates the documentation accordingly.