### PR TITLE
Update Klutch dependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Develop
 
+* Chore: Update to latest versions of the following components: nginx-ingress, Dex, Crossplane, anynines-backend and its CRDs, kubectl-bind and konnector.
+
 # v0.14.1
 * Change: Removed dependency on a8s-demo repository.
 * Change: If the user chooses a relative working directory, it is converted to an absolute path before being stored.

--- a/docs/docs/a9s-cli-klutch.md
+++ b/docs/docs/a9s-cli-klutch.md
@@ -39,19 +39,19 @@ This will allow you to use `a8s` resource instances such as `postgresql` on the 
 ## Prerequisites
 - [General prerequisites](./a9s-cli-index.md#prerequisites) are met.
 - Install [Helm](https://helm.sh/docs/intro/install/).
-- Install `kubectl-bind` plugin version 1.3.0 or higher (see below).
+- Install `kubectl-bind` plugin version 1.4.1 or higher (see below).
 - On **linux**, docker must be runnable without sudo. See the [docker documentation](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) for further details.
 
 ### Installing the `kubectl-bind` plugin:
 
 Download a binary for your platform with the following URL, make it executable and place it in a location in your `PATH`:
 
-`https://anynines-artifacts.s3.eu-central-1.amazonaws.com/central-management/v1.3.0/$OS-$ARCH/kubectl-bind`
+`https://anynines-artifacts.s3.eu-central-1.amazonaws.com/central-management/v1.4.1/$OS-$ARCH/kubectl-bind`
 
 Replace `OS` and `ARCH` with values for your platform, e.g. `darwin-arm64` or `linux-amd64`. You can also use the following script to achieve this:
 
 ```bash
-RELEASE="v1.3.0"
+RELEASE="v1.4.1"
 OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -fsSL -o kubectl-bind https://anynines-artifacts.s3.eu-central-1.amazonaws.com/central-management/$RELEASE/$OS-$ARCH/kubectl-bind
 
 sudo chmod 755 kubectl-bind

--- a/klutch/README.md
+++ b/klutch/README.md
@@ -11,7 +11,7 @@ The following assumptions for using `klutch` commands are made:
 - `kind`, `kubectl`, `helm`, `git` are present in the PATH.
 - The following external resources are reachable:
     - Files on https://raw.githubusercontent.com/
-    - https://anynines-artifacts.s3.eu-central-1.amazonaws.com/central-management/v1.3.0/crds.yaml
+    - https://anynines-artifacts.s3.eu-central-1.amazonaws.com/central-management/v1.4.1/crds.yaml
     - `public.ecr.aws/w5n9a2g2/anynines/` image repositories
     - `dexidp/dex` image
     - `curlimages/curl` image
@@ -35,7 +35,7 @@ This allows subsequent commands such as `bind` to correctly connect to the Contr
 `a9s klutch bind`
 
 It makes following assumptions:
-- `kubectl` and the `kubectl-bind` plugin (`v1.3.0`) are present in the PATH.
+- `kubectl` and the `kubectl-bind` plugin (`v1.4.1`) are present in the PATH.
 
 This command automates the interactive binding process where possible. The `kubectl bind` command is called, opening a browser tab/window where the authorization can be performed. Once this is completed, the automation resumes and finishes the binding process.
 

--- a/klutch/backend.go
+++ b/klutch/backend.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	backendCRDManifestsURL = "https://anynines-artifacts.s3.eu-central-1.amazonaws.com/central-management/v1.3.0/crds.yaml"
+	backendCRDManifestsURL = "https://anynines-artifacts.s3.eu-central-1.amazonaws.com/central-management/v1.4.1/crds.yaml"
 )
 
 //go:embed templates/backend.tmpl

--- a/klutch/bind.go
+++ b/klutch/bind.go
@@ -35,7 +35,7 @@ var backupExample string
 var restoreExample string
 
 const (
-	konnectorImage = "public.ecr.aws/w5n9a2g2/anynines/konnector:v1.3.0"
+	konnectorImage = "public.ecr.aws/w5n9a2g2/anynines/konnector:v1.4.1"
 )
 
 type NamespacedName = types.NamespacedName

--- a/klutch/crossplane.go
+++ b/klutch/crossplane.go
@@ -14,7 +14,7 @@ const (
 	configPackageName = "anynines-dataservices"
 	// replace with kustomization so everything that is needed gets installed, even after minor version bump
 	configPackageManifestUrl = "https://raw.githubusercontent.com/anynines/klutchio/refs/tags/v1.3.0/crossplane-api/deploy/config-pkg-anynines.yaml"
-	helmChartUrl             = "https://charts.crossplane.io/stable/crossplane-1.17.1.tgz"
+	helmChartUrl             = "https://charts.crossplane.io/stable/crossplane-1.19.0.tgz"
 )
 
 //go:embed manifests/provider-kubernetes.yaml

--- a/klutch/ingress.go
+++ b/klutch/ingress.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ingressManifestsUrl = "https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.11.1/deploy/static/provider/kind/deploy.yaml"
+	ingressManifestsUrl = "https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.12.1/deploy/static/provider/kind/deploy.yaml"
 )
 
 //go:embed manifests/nginx-ingress-config.yaml

--- a/klutch/manifests/nginx-ingress-config.yaml
+++ b/klutch/manifests/nginx-ingress-config.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.11.1
   name: ingress-nginx-controller
   namespace: ingress-nginx
 data:

--- a/klutch/templates/backend.tmpl
+++ b/klutch/templates/backend.tmpl
@@ -31,7 +31,7 @@ spec:
             done
       containers:
       - name: anynines-backend
-        image: public.ecr.aws/w5n9a2g2/anynines/kubebind-backend:v1.3.0
+        image: public.ecr.aws/w5n9a2g2/anynines/kubebind-backend:v1.4.1
         args:
         - --namespace-prefix=kube-bind-
         - --pretty-name=anynines

--- a/klutch/templates/dex.tmpl
+++ b/klutch/templates/dex.tmpl
@@ -95,7 +95,7 @@ spec:
     spec:
       containers:
       - name: dex
-        image: dexidp/dex:v2.41.1-distroless
+        image: dexidp/dex:v2.42.0-distroless
         args:
         - dex
         - serve


### PR DESCRIPTION
This PR updates various components used in the klutch related commands:

- nginx-ingress due to a vulnerability.
- dex
- backend-anynines
- konnector & bind
- crossplane