### PR TITLE
A8s 2993 investigate fix failing e2e tests for a9s cli v2

### DIFF
--- a/demo/config.go
+++ b/demo/config.go
@@ -350,49 +350,50 @@ func establishBackupStoreConfigYaml() {
 	filePath := backupStoreConfigFilePath()
 
 	if CheckIfFileExists(filePath) {
-		makeup.PrintCheckmark(fmt.Sprintf("There's already a backup-store-config.yaml file at %s. Trusting that the file is ok.", filePath))
+		makeup.PrintCheckmark(fmt.Sprintf("There's already a backup-store-config.yaml file at %s. Old configuration data will be overwritten if there were changes to them.", filePath))
 	} else {
-		makeup.Print("Writing a backup-store-config.yaml with defaults to " + filePath)
-
-		var actualProvider string
-
-		// For minio the backup_agent will be configured using an S3 compatible storage client
-		if strings.ToLower(BackupInfrastructureProvider) == "minio" {
-			actualProvider = "AWS"
-
-			// The endpoint is not set as a default cmd param as with AWS as a provider, this endpoint would cause problems
-			BackupInfrastructureEndpoint = "http://minio.minio-dev.svc.cluster.local:9000"
-			BackupInfrastructurePathStyle = true
-		} else {
-			actualProvider = BackupInfrastructureProvider
-		}
-
-		// TODO Make backup store configurable
-		blobStoreConfig := BlobStore{
-			Config: BlobStoreConfig{
-				CloudConfig: BlobStoreCloudConfiguration{
-					Provider:  actualProvider,
-					Container: BackupInfrastructureBucket,
-					Region:    BackupInfrastructureRegion,
-					Endpoint:  BackupInfrastructureEndpoint,
-					PathStyle: BackupInfrastructurePathStyle,
-				},
-			},
-		}
-
-		//TODO Refactor using WriteYAMLToFile
-		yamlData, err := yaml.Marshal(&blobStoreConfig)
-
-		if err != nil {
-			makeup.ExitDueToFatalError(err, "Couldn't generate backup-store-config.yaml file. Aborting...")
-		}
-
-		err = os.WriteFile(filePath, yamlData, 0644)
-
-		if err != nil {
-			makeup.ExitDueToFatalError(err, "Couldn't save backup-store-config.yaml file. Aborting...")
-		}
+		makeup.Print("Writing a backup-store-config.yaml with configurations to " + filePath)
 	}
+
+	var actualProvider string
+
+	// For minio the backup_agent will be configured using an S3 compatible storage client
+	if strings.ToLower(BackupInfrastructureProvider) == "minio" {
+		actualProvider = "AWS"
+
+		// The endpoint is not set as a default cmd param as with AWS as a provider, this endpoint would cause problems
+		BackupInfrastructureEndpoint = "http://minio.minio-dev.svc.cluster.local:9000"
+		BackupInfrastructurePathStyle = true
+	} else {
+		actualProvider = BackupInfrastructureProvider
+	}
+
+	// TODO Make backup store configurable
+	blobStoreConfig := BlobStore{
+		Config: BlobStoreConfig{
+			CloudConfig: BlobStoreCloudConfiguration{
+				Provider:  actualProvider,
+				Container: BackupInfrastructureBucket,
+				Region:    BackupInfrastructureRegion,
+				Endpoint:  BackupInfrastructureEndpoint,
+				PathStyle: BackupInfrastructurePathStyle,
+			},
+		},
+	}
+
+	//TODO Refactor using WriteYAMLToFile
+	yamlData, err := yaml.Marshal(&blobStoreConfig)
+
+	if err != nil {
+		makeup.ExitDueToFatalError(err, "Couldn't generate backup-store-config.yaml file. Aborting...")
+	}
+
+	err = os.WriteFile(filePath, yamlData, 0644)
+
+	if err != nil {
+		makeup.ExitDueToFatalError(err, "Couldn't save backup-store-config.yaml file. Aborting...")
+	}
+
 }
 
 func GetConfig() Config {

--- a/e2e-tests/Readme.md
+++ b/e2e-tests/Readme.md
@@ -18,7 +18,12 @@ The idea is that Ruby is more user friendly when it comes to writing scripts tha
 
 1. Install the `a9s` cli and ensure it's in your `$PATH`.
 2. Run the `a9s demo a8s` for both `kind` and `minikube`. This ensures that all dependencies are there and creates a local working directory.
-3. In the `e2e-tests` folger run the test suite by executing: `bundle exec rspec`
+3. Create an AWS S3 bucket (one of the e2e-tests uses Minikube and AWS S3 as its backup storage)
+4. Set the following ENV vars with your AWS account's credentials:
+  `export AWS_ACCESSKEYID=<...>`
+  `export AWS_SECRETKEY=<...>`  
+  `export ASW_S3_BUCKET_NAME=<...>`
+5. In the `e2e-tests` directory run the test suite by executing: `bundle exec rspec`
   * Before the first execution: 
     * [Recommended but optional] Install the Docker Pull Through Registry as this will speed up the test execution reducing the runtime to about 20%.    
     * Ensure that you have installed both Ruby and Bundler.

--- a/e2e-tests/spec/features/a9s_cli_spec.rb
+++ b/e2e-tests/spec/features/a9s_cli_spec.rb
@@ -337,6 +337,9 @@ RSpec.describe "a9s-cli" do
               cmd = 'a9s create cluster a8s -p minikube --verbose --yes' \
                   ' --backup-provider="AWS"' \
                   ' --backup-region="eu-central-1"'
+              cmd += ' --backup-bucket="'
+              cmd += ENV.fetch('ASW_S3_BUCKET_NAME')
+              cmd += "\""
               cmd += ' --backup-store-accesskey="'
               cmd += ENV.fetch('AWS_ACCESSKEYID')
               cmd += "\""


### PR DESCRIPTION
These additions fix the e2e-test cases that use Minikube and AWS S3 as a backup storage.