### PR TITLE
Updates docs url for kubectl-bind plugin

### DIFF
--- a/prerequisites/prerequisites.go
+++ b/prerequisites/prerequisites.go
@@ -97,8 +97,8 @@ func GetCommonRequiredTools() map[string]RequiredTool {
 		ToolBind: {
 			CommandName: ToolBind,
 			HelpURLs: map[string]string{
-				GOOSDarwin: "https://docs.k8s.anynines.com/docs/develop/platform-operator/central-management-cluster-setup/#binding-an-app-cluster-interactive",
-				GOOSLinux:  "https://docs.k8s.anynines.com/docs/develop/platform-operator/central-management-cluster-setup/#binding-an-app-cluster-interactive",
+				GOOSDarwin: "https://klutch.io/docs/platform-operator-guide/setting-up-klutch-clusters/app-cluster/#installing-the-klutch-bind-cli",
+				GOOSLinux:  "https://klutch.io/docs/platform-operator-guide/setting-up-klutch-clusters/app-cluster/#installing-the-klutch-bind-cli",
 			},
 		},
 	}


### PR DESCRIPTION
When the command 'a9s klutch bind' command is executed while the kubectl-bind plugin was not installed, the CLI would print out a url to point towards the docs for installing said plugin. This url was outdated and is now being updated.