### PR TITLE
Fix IP Quota Checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13
 	github.com/sethvargo/go-password v0.2.0
 	github.com/spf13/cobra v1.8.1
+	golang.org/x/mod v0.30.0
 	golang.org/x/oauth2 v0.28.0
 	golang.org/x/term v0.38.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,8 @@ golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.30.0 h1:fDEXFVZ/fmCKProc/yAXXUijritrDzahmwwefnjoPFk=
+golang.org/x/mod v0.30.0/go.mod h1:lAsf5O2EvJeSFMiBxXDki7sCgAxEUcZHXoXMKT4GJKc=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/klutch/aws/control_plane.go
+++ b/klutch/aws/control_plane.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/anynines/a9s-cli-v2/k8s"
 	"github.com/anynines/a9s-cli-v2/makeup"
+	"golang.org/x/mod/semver"
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
@@ -117,6 +119,10 @@ var (
 	defaultTenantOperatorImage        = "public.ecr.aws/h6x7g6i7/anynines/cli-resources/tenants-operator:0.1.0"
 	defaultTenantOperatorChartImage   = "oci://public.ecr.aws/h6x7g6i7/anynines/cli-resources/tenants-operator-chart"
 	defaultTenantOperatorChartVersion = "0.1.0"
+	// date of pinning: 16.04.26;
+	// reason for pinning: serviceManaged field in DescribeAddresses API
+	// response is required
+	awsCliMinimumVersion = "2.24.20"
 )
 
 func setKlutchContext(cfg Config) func() {
@@ -360,6 +366,7 @@ func provisionCluster(ctx context.Context, cfg Config, opts CreateOptions) {
 				awsLogger.Fatalf(err, "Required command %q is not installed or not in PATH", cmd)
 			}
 		}
+		checkAWSCLIVersion(ctx)
 		awsLogger.Successf("All required commands (%s) are available.", strings.Join(requiredCmds, ", "))
 	}
 
@@ -498,6 +505,22 @@ func provisionCluster(ctx context.Context, cfg Config, opts CreateOptions) {
 	awsLogger.Printf("   Region:    %s", cfg.Region)
 	awsLogger.Printf("   VPC:       %s", vpcID)
 	awsLogger.Printf("   KMS Key:   %s", keyArn)
+}
+
+func checkAWSCLIVersion(ctx context.Context) {
+	out, errOut, err := runCmd(ctx, "aws", "--version")
+	if err != nil {
+		awsLogger.Fatalf(err, "Could not check for aws CLI version:\n %s", errOut)
+	}
+	pattern := regexp.MustCompile(`aws-cli/([0-9]+\.[0-9]+\.[0-9]+)`)
+	match := pattern.FindStringSubmatch(out)
+	if len(match) < 2 {
+		awsLogger.Fatalf(err, "Could not extract aws CLI version:\n %s", errOut)
+	}
+	version := match[1]
+	if cmp := semver.Compare(version, awsCliMinimumVersion); cmp < 0 {
+		awsLogger.Fatalf(nil, "AWS CLI version %s is not supported, minimum required version is %s", version, awsCliMinimumVersion)
+	}
 }
 
 func printCreatePlan(cfg Config) {
@@ -1182,12 +1205,10 @@ func ensurePublicRouteTable(ctx context.Context, vpcID, igwID string, pubSubnets
 	return rtID
 }
 
-func ensureElasticIPQuota(ctx context.Context, missingNats int) {
-	// multiplying by 2 since every NAT uses 2 IPs
-	required := missingNats * 2
+func ensureElasticIPQuota(ctx context.Context, required int) {
 	awsLogger.Infof("Checking Elastic IP quota (need %d new EIPs)...", required)
 	out, errOut, err := runCmd(ctx, "aws", "ec2", "describe-addresses",
-		"--query", "Addresses[].AllocationId",
+		"--query", "Addresses[?!ServiceManaged].AllocationId",
 		"--output", "text")
 	currentCount := 0
 	if err == nil && strings.TrimSpace(out) != "" {
@@ -1238,13 +1259,13 @@ func ensureNATs(ctx context.Context, vpcID, pubA, pubB, pubC string) (string, st
 			natIDs[zone] = natID
 		}
 	}
-	missingNATs := 3 - len(natIDs)
+	missingNATs := len(natSubnets) - len(natIDs)
 	if missingNATs > 0 {
 		ensureElasticIPQuota(ctx, missingNATs)
 	}
 	for zone, subnet := range natSubnets {
 		if natIDs[zone] != "" {
-			awsLogger.Successf("Reusing NAT Gateway: %s", subnet)
+			awsLogger.Successf("Reusing NAT Gateway: %s", natIDs[zone])
 			tagExistingNatResources(ctx, natIDs[zone], zone)
 			continue
 		}
@@ -1260,6 +1281,7 @@ func ensureNATs(ctx context.Context, vpcID, pubA, pubB, pubC string) (string, st
 			"--query", "NatGateway.NatGatewayId",
 			"--output", "text")
 		tagEC2Resource(ctx, natID, resourceName("nat-gateway", zone))
+		natIDs[zone] = natID
 		createdNewNats = true
 	}
 

--- a/klutch/aws/control_plane.go
+++ b/klutch/aws/control_plane.go
@@ -6,9 +6,11 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1034,7 +1036,6 @@ func ensureNetworking(ctx context.Context, cfg Config, vpcID string) {
 
 	publicRT := ensurePublicRouteTable(ctx, vpcID, igwID, []string{pubA, pubB, pubC})
 
-	ensureElasticIPQuota(ctx)
 	natA, natB, natC := ensureNATs(ctx, vpcID, pubA, pubB, pubC)
 
 	privRTA := ensurePrivateRT(ctx, vpcID, privA, natA, resourceName("private-route-table-a"))
@@ -1181,8 +1182,10 @@ func ensurePublicRouteTable(ctx context.Context, vpcID, igwID string, pubSubnets
 	return rtID
 }
 
-func ensureElasticIPQuota(ctx context.Context) {
-	awsLogger.Infof("Checking Elastic IP quota...")
+func ensureElasticIPQuota(ctx context.Context, missingNats int) {
+	// multiplying by 2 since every NAT uses 2 IPs
+	required := missingNats * 2
+	awsLogger.Infof("Checking Elastic IP quota (need %d new EIPs)...", required)
 	out, errOut, err := runCmd(ctx, "aws", "ec2", "describe-addresses",
 		"--query", "Addresses[].AllocationId",
 		"--output", "text")
@@ -1193,7 +1196,6 @@ func ensureElasticIPQuota(ctx context.Context) {
 	} else if err != nil && !strings.Contains(errOut, "AuthFailure") {
 		awsLogger.Warningf("describe-addresses failed: %v, stderr: %s", err, errOut)
 	}
-	required := 3
 	quotaRaw, errOutQ, errQ := runCmd(ctx, "aws", "service-quotas", "get-service-quota",
 		"--service-code", "ec2",
 		"--quota-code", "L-0263D0A3",
@@ -1220,8 +1222,11 @@ func ensureElasticIPQuota(ctx context.Context) {
 
 func ensureNATs(ctx context.Context, vpcID, pubA, pubB, pubC string) (string, string, string) {
 	awsLogger.Infof("Ensuring NAT Gateways exist...")
-	var newNATs []string
-	ensure := func(subnet, label string) string {
+	createdNewNats := false
+	natSubnets := map[string]string{"a": pubA, "b": pubB, "c": pubC}
+	natIDs := map[string]string{}
+	// First, check which NATs need to be created
+	for zone, subnet := range natSubnets {
 		natID, _, _ := runCmd(ctx, "aws", "ec2", "describe-nat-gateways",
 			"--filter",
 			"Name=vpc-id,Values="+vpcID,
@@ -1229,38 +1234,43 @@ func ensureNATs(ctx context.Context, vpcID, pubA, pubB, pubC string) (string, st
 			"Name=state,Values=available",
 			"--query", "NatGateways[0].NatGatewayId",
 			"--output", "text")
-		if natID == "" || natID == "None" || natID == "null" {
-			awsLogger.Infof("Creating NAT Gateway in subnet %s...", subnet)
-			alloc := mustRun(ctx, "aws", "ec2", "allocate-address",
-				"--domain", "vpc",
-				"--query", "AllocationId",
-				"--output", "text")
-			tagEC2Resource(ctx, alloc, resourceName("nat-eip", label))
-			natID = mustRun(ctx, "aws", "ec2", "create-nat-gateway",
-				"--subnet-id", subnet,
-				"--allocation-id", alloc,
-				"--query", "NatGateway.NatGatewayId",
-				"--output", "text")
-			tagEC2Resource(ctx, natID, resourceName("nat-gateway", label))
-			newNATs = append(newNATs, natID)
-		} else {
-			awsLogger.Successf("Reusing NAT Gateway: %s", natID)
-			tagExistingNatResources(ctx, natID, label)
+		if !(natID == "" || natID == "None" || natID == "null") {
+			natIDs[zone] = natID
 		}
-		return natID
 	}
-	natA := ensure(pubA, "a")
-	natB := ensure(pubB, "b")
-	natC := ensure(pubC, "c")
+	missingNATs := 3 - len(natIDs)
+	if missingNATs > 0 {
+		ensureElasticIPQuota(ctx, missingNATs)
+	}
+	for zone, subnet := range natSubnets {
+		if natIDs[zone] != "" {
+			awsLogger.Successf("Reusing NAT Gateway: %s", subnet)
+			tagExistingNatResources(ctx, natIDs[zone], zone)
+			continue
+		}
+		awsLogger.Infof("Creating NAT Gateway in subnet %s...", subnet)
+		alloc := mustRun(ctx, "aws", "ec2", "allocate-address",
+			"--domain", "vpc",
+			"--query", "AllocationId",
+			"--output", "text")
+		tagEC2Resource(ctx, alloc, resourceName("nat-eip", zone))
+		natID := mustRun(ctx, "aws", "ec2", "create-nat-gateway",
+			"--subnet-id", subnet,
+			"--allocation-id", alloc,
+			"--query", "NatGateway.NatGatewayId",
+			"--output", "text")
+		tagEC2Resource(ctx, natID, resourceName("nat-gateway", zone))
+		createdNewNats = true
+	}
 
-	if len(newNATs) > 0 {
+	if createdNewNats {
 		args := []string{"ec2", "wait", "nat-gateway-available", "--nat-gateway-ids"}
-		args = append(args, newNATs...)
+		args = append(args, slices.Collect(maps.Values(natIDs))...)
 		mustRun(ctx, "aws", args...)
 		awsLogger.Successf("New NAT Gateways are available.")
 	}
-	awsLogger.Printf("NAT Gateways: %s, %s, %s", natA, natB, natC)
-	return natA, natB, natC
+	awsLogger.Printf("NAT Gateways: %s, %s, %s", natIDs["a"], natIDs["b"], natIDs["c"])
+	return natIDs["a"], natIDs["b"], natIDs["c"]
 }
 
 func tagExistingNatResources(ctx context.Context, natID, label string) {

--- a/klutch/aws/control_plane.go
+++ b/klutch/aws/control_plane.go
@@ -122,7 +122,7 @@ var (
 	// date of pinning: 16.04.26;
 	// reason for pinning: serviceManaged field in DescribeAddresses API
 	// response is required
-	awsCliMinimumVersion = "2.24.20"
+	awsCliMinimumVersion = "v2.24.20"
 )
 
 func setKlutchContext(cfg Config) func() {
@@ -517,7 +517,7 @@ func checkAWSCLIVersion(ctx context.Context) {
 	if len(match) < 2 {
 		awsLogger.Fatalf(err, "Could not extract aws CLI version:\n %s", errOut)
 	}
-	version := match[1]
+	version := "v" + match[1]
 	if cmp := semver.Compare(version, awsCliMinimumVersion); cmp < 0 {
 		awsLogger.Fatalf(nil, "AWS CLI version %s is not supported, minimum required version is %s", version, awsCliMinimumVersion)
 	}


### PR DESCRIPTION
Fix bug where
- CLI would check ElasticIP quota regardless of whether new IPs are needed
- CLI would check for 1 IP per NAT even though in reality each NAT uses 2 IPs