### PR TITLE
docs: add concepts and troubleshooting pages (KLT-1086)

### DIFF
--- a/docs/docs/a9s-cli-reference/_category_.json
+++ b/docs/docs/a9s-cli-reference/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "a9s CLI Reference",
+  "position": 3
+}

--- a/docs/docs/concepts/_category_.json
+++ b/docs/docs/concepts/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Concepts",
+  "position": 1
+}

--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -79,13 +79,32 @@ For Klutch resources in a **Workload** cluster — PostgreSQL instances, Service
 
 An object can show `READY` while the thing it asked for is still being created, or has failed.
 
-To check the true state, read the `.status.managed` field of the object in the Workload cluster:
+Here is the trap in practice. Seconds after creating a PostgreSQL instance, `kubectl get` already reports it ready:
+
+```
+NAME                    SYNCED   READY   CONNECTION-SECRET   AGE
+my-klutch-pg-instance   True     True                        10s
+```
+
+But the database does not exist yet:
 
 ```bash
 kubectl get postgresqlinstances.anynines.com "${PG}" -n "${NS}" \
   -o jsonpath='{.status.managed}'
 ```
 
-The same applies to `servicebindings.anynines.com`, `backups.anynines.com`, and `restores.anynines.com`.
+```json
+{"clusterStatus":"Pending"}
+```
+
+Roughly two minutes later, the same command returns a healthy instance — one running replica:
+
+```json
+{"clusterStatus":"Running","readyReplicas":1}
+```
+
+`READY` never changed. Only `.status.managed` did.
+
+Wait for `clusterStatus` to reach `Running` before using the instance. The same field applies to `servicebindings.anynines.com`, `backups.anynines.com`, and `restores.anynines.com`, though the keys inside it differ by resource kind.
 
 Anywhere the tutorials tell you to wait for something, `.status.managed` is the field that answers the question.

--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -1,0 +1,91 @@
+---
+id: concepts-index
+title: Concepts
+sidebar_position: 1
+tags:
+  - klutch
+  - concepts
+  - architecture
+keywords:
+  - klutch
+  - control plane
+  - workload cluster
+  - tenant
+  - bind
+  - konnector
+  - crossplane claim
+---
+
+The rest of this documentation uses these terms as command arguments and object kinds. Read this page first if any of them are new — the tutorials assume them.
+
+## Control Plane cluster and Workload cluster
+
+Klutch splits responsibilities across two Kubernetes clusters.
+
+The **Control Plane cluster** runs the machinery: Crossplane, the a8s PostgreSQL operator, the Klutch-Bind backend, and the Tenant operator. Data service instances are actually provisioned here.
+
+A **Workload cluster** is where application teams work. It runs no operators of its own. Once bound to a Control Plane, it gains the Klutch resource kinds — `postgresqlinstances.anynines.com` and friends — and a developer submits requests there without needing access to the Control Plane.
+
+A single Control Plane serves many Workload clusters. The `a9s` CLI creates each with a different command: `a9s create cluster klutch control-plane` and `a9s create cluster klutch workload`.
+
+:::note
+
+The Klutch project's own documentation calls a Workload cluster an **app cluster**. Same thing; this documentation uses "Workload cluster" throughout, matching the CLI's command names.
+
+:::
+
+## Tenant
+
+A **Tenant** represents an entity — a team, a project, an environment — that will bind Workload clusters to a Control Plane.
+
+Creating one with `a9s create klutch tenant` makes the Tenant operator:
+
+1. Create a **Cognito app client** with a `client_credentials` grant and a `klutch/bind` scope.
+2. Store the resulting OIDC credentials in **AWS Secrets Manager**.
+
+Those credentials are then consumed automatically when a Workload cluster binds, which is why binding on AWS needs no interactive login.
+
+## bind and the konnector
+
+**Binding** is what connects a Workload cluster to a Control Plane. It establishes an OIDC-authenticated session and installs the konnector.
+
+The **konnector** is a lightweight agent that runs in the Workload cluster and maintains that session. It carries submissions from the Workload cluster to the Control Plane and brings status back. It is the reason a Workload cluster can offer data service APIs while running no operators itself.
+
+The sync is always initiated by the Workload cluster. The Control Plane does not reach into it.
+
+## Crossplane Claim
+
+A **Claim** is the namespace-scoped resource a developer submits to ask for a data service instance — a `PostgresqlInstance`, a `ServiceBinding`, a `Backup`, a `Restore`.
+
+Crossplane reconciles each Claim into a cluster-scoped **Composite Resource (XR)** on the Control Plane, and a provider turns that into a real instance. You normally interact only with Claims.
+
+When you run `a9s create klutch pg instance`, you are creating a Claim.
+
+## a8s objects and Klutch remote claims
+
+Both tutorials provision PostgreSQL, but through different mechanisms, and the object kinds differ.
+
+The **local a8s tutorial** talks to the a8s PostgreSQL operator directly. Objects are the operator's own kinds — `postgresqls.postgresql.anynines.com`, `servicebindings.anynines.com` — and they live in the one cluster you created.
+
+The **Klutch AWS tutorial** goes through Crossplane. Objects are Claims — `postgresqlinstances.anynines.com` — submitted in the Workload cluster and reconciled on the Control Plane.
+
+Similar names, different mechanisms. A command from one tutorial will not work in the other's cluster.
+
+## `READY` versus `.status.managed`
+
+This distinction decides whether you can tell success from failure, and it catches people out.
+
+For Klutch resources in a **Workload** cluster — PostgreSQL instances, Service Bindings, Backups, Restores — the `READY` condition reflects **propagation status**: whether the konnector has synced the object to the Control Plane. It does **not** report whether the underlying database, binding, backup, or restore is actually ready.
+
+An object can show `READY` while the thing it asked for is still being created, or has failed.
+
+To check the true state, read the `.status.managed` field of the object in the Workload cluster:
+
+```bash
+kubectl get postgresqlinstances.anynines.com "${PG}" -n "${NS}" \
+  -o jsonpath='{.status.managed}'
+```
+
+The same applies to `servicebindings.anynines.com`, `backups.anynines.com`, and `restores.anynines.com`.
+
+Anywhere the tutorials tell you to wait for something, `.status.managed` is the field that answers the question.

--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -16,7 +16,7 @@ keywords:
   - crossplane claim
 ---
 
-The rest of this documentation uses these terms as command arguments and object kinds. Read this page first if any of them are new — the tutorials assume them.
+The rest of this documentation uses these terms as command arguments and object kinds. Read this page first if any of them are new. The tutorials assume them.
 
 ## Control Plane cluster and Workload cluster
 
@@ -24,7 +24,7 @@ Klutch splits responsibilities across two Kubernetes clusters.
 
 The **Control Plane cluster** runs the machinery: Crossplane, the a8s PostgreSQL operator, the Klutch-Bind backend, and the Tenant operator. Data service instances are actually provisioned here.
 
-A **Workload cluster** is where application teams work. It runs no operators of its own. Once bound to a Control Plane, it gains the Klutch resource kinds — `postgresqlinstances.anynines.com` and friends — and a developer submits requests there without needing access to the Control Plane.
+A **Workload cluster** is where application teams work. It runs no operators of its own. Once bound to a Control Plane, it gains the Klutch resource kinds (`postgresqlinstances.anynines.com` and friends), and a developer submits requests there without needing access to the Control Plane.
 
 A single Control Plane serves many Workload clusters. The `a9s` CLI creates each with a different command: `a9s create cluster klutch control-plane` and `a9s create cluster klutch workload`.
 
@@ -36,7 +36,7 @@ The Klutch project's own documentation calls a Workload cluster an **app cluster
 
 ## Tenant
 
-A **Tenant** represents an entity — a team, a project, an environment — that will bind Workload clusters to a Control Plane.
+A **Tenant** represents an entity that will bind Workload clusters to a Control Plane: a team, a project, or an environment.
 
 Creating one with `a9s create klutch tenant` makes the Tenant operator:
 
@@ -55,7 +55,7 @@ The sync is always initiated by the Workload cluster. The Control Plane does not
 
 ## Crossplane Claim
 
-A **Claim** is the namespace-scoped resource a developer submits to ask for a data service instance — a `PostgresqlInstance`, a `ServiceBinding`, a `Backup`, a `Restore`.
+A **Claim** is the namespace-scoped resource a developer submits to ask for a data service instance: a `PostgresqlInstance`, a `ServiceBinding`, a `Backup`, a `Restore`.
 
 Crossplane reconciles each Claim into a cluster-scoped **Composite Resource (XR)** on the Control Plane, and a provider turns that into a real instance. You normally interact only with Claims.
 
@@ -65,9 +65,9 @@ When you run `a9s create klutch pg instance`, you are creating a Claim.
 
 Both tutorials provision PostgreSQL, but through different mechanisms, and the object kinds differ.
 
-The **local a8s tutorial** talks to the a8s PostgreSQL operator directly. Objects are the operator's own kinds — `postgresqls.postgresql.anynines.com`, `servicebindings.anynines.com` — and they live in the one cluster you created.
+The **local a8s tutorial** talks to the a8s PostgreSQL operator directly. Objects are the operator's own kinds (`postgresqls.postgresql.anynines.com`, `servicebindings.anynines.com`), and they live in the one cluster you created.
 
-The **Klutch AWS tutorial** goes through Crossplane. Objects are Claims — `postgresqlinstances.anynines.com` — submitted in the Workload cluster and reconciled on the Control Plane.
+The **Klutch AWS tutorial** goes through Crossplane. Objects are Claims (`postgresqlinstances.anynines.com`) submitted in the Workload cluster and reconciled on the Control Plane.
 
 Similar names, different mechanisms. A command from one tutorial will not work in the other's cluster.
 
@@ -75,7 +75,7 @@ Similar names, different mechanisms. A command from one tutorial will not work i
 
 This distinction decides whether you can tell success from failure, and it catches people out.
 
-For Klutch resources in a **Workload** cluster — PostgreSQL instances, Service Bindings, Backups, Restores — the `READY` condition reflects **propagation status**: whether the konnector has synced the object to the Control Plane. It does **not** report whether the underlying database, binding, backup, or restore is actually ready.
+For Klutch resources in a **Workload** cluster (PostgreSQL instances, Service Bindings, Backups, Restores), the `READY` condition reflects **propagation status**: whether the konnector has synced the object to the Control Plane. It does **not** report whether the underlying database, binding, backup, or restore is actually ready.
 
 An object can show `READY` while the thing it asked for is still being created, or has failed.
 
@@ -97,7 +97,7 @@ kubectl get postgresqlinstances.anynines.com "${PG}" -n "${NS}" \
 {"clusterStatus":"Pending"}
 ```
 
-Roughly two minutes later, the same command returns a healthy instance — one running replica:
+Roughly two minutes later, the same command returns a healthy instance with one running replica:
 
 ```json
 {"clusterStatus":"Running","readyReplicas":1}

--- a/docs/docs/hands-on-tutorials/_category_.json
+++ b/docs/docs/hands-on-tutorials/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Hands-On Tutorials",
+  "position": 2
+}

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -1,0 +1,84 @@
+---
+id: troubleshooting
+title: Troubleshooting
+sidebar_position: 5
+tags:
+  - troubleshooting
+  - klutch
+  - aws
+keywords:
+  - troubleshooting
+  - cognito
+  - hosted zone
+  - kube context
+  - known issues
+---
+
+Known hazards you can hit while following the tutorials, and what each one looks like when it happens.
+
+## Control plane creation appears to hang for 30+ minutes
+
+**Symptom.** `a9s create cluster klutch control-plane` sits without visible progress during the Cognito step. The step is documented as taking about 20 minutes; it runs well past that.
+
+**Cause.** The IPv6 endpoint for AWS Cognito is sometimes very slow to respond — minutes per call — while the IPv4 endpoint answers immediately. The Cognito setup can add up to **35 minutes** to control plane creation as a result.
+
+**What to do.** Temporarily disable IPv6 resolution before running the step. On macOS:
+
+```bash
+networksetup -setv6off Wi-Fi
+```
+
+Re-enable it afterwards:
+
+```bash
+networksetup -setv6automatic Wi-Fi
+```
+
+The command is not stuck and does not need interrupting — it is waiting on Cognito.
+
+## Hosted zone never becomes resolvable
+
+**Symptom.** Control plane creation prints a set of NS records and then polls, without completing.
+
+**Cause.** The `a9s` CLI created a child hosted zone but could not find its parent in the current AWS account, so it cannot add the delegation records itself. The zone stays unresolvable until they exist.
+
+**What to do.** Add an `NS` record to the parent zone, in the account that holds it, with the child zone's name as the record name and the printed name servers as the value. The CLI polls for up to 30 minutes and continues on its own once the delegation resolves.
+
+Deleting such a zone later is also manual — see the warning on the teardown step of the AWS tutorial.
+
+## Commands act on the wrong cluster
+
+**Symptom.** `kubectl` reports that a resource does not exist when you just created it, or a Klutch resource kind is unrecognised.
+
+**Cause.** The AWS tutorial moves between the Control Plane and Workload clusters several times. Every command's correctness depends on which one your kubeconfig currently points at, and nothing in the shell prompt tells you.
+
+**What to do.** Confirm the current context before running commands against a cluster:
+
+```bash
+kubectl config current-context
+```
+
+To list the Klutch clusters the CLI knows about and switch between them:
+
+```bash
+a9s get clusters klutch
+a9s use klutch --cluster-name <name>
+```
+
+Remember that Klutch resource kinds only exist in a **Workload** cluster after it has been bound, and that `a9s pg apply` runs against the **Control Plane**.
+
+## Backup data remains in Minio after deletion
+
+**Symptom.** Backups are deleted through the API, but their data is still present in the Minio object store on the Control Plane cluster.
+
+**Cause.** A known issue: the a8s Backup Manager does not remove backup data from Minio when the Backup object is deleted. A fix is in progress.
+
+**What to do.** Nothing is required for the tutorials to work. Be aware that tearing down Klutch resources does not reclaim that storage, and that it survives until the cluster itself is deleted.
+
+## An object says `READY` but nothing works
+
+**Symptom.** A PostgreSQL instance, Service Binding, Backup, or Restore in the Workload cluster reports `READY`, but connecting or using it fails.
+
+**Cause.** `READY` on these objects reflects whether the konnector propagated them to the Control Plane — not whether the underlying resource is usable.
+
+**What to do.** Read `.status.managed` instead. See [`READY` versus `.status.managed`](./concepts/index.md) in Concepts for the full explanation and the exact command.

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 id: troubleshooting
 title: Troubleshooting
-sidebar_position: 5
+sidebar_position: 4
 tags:
   - troubleshooting
   - klutch

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -20,7 +20,7 @@ Known hazards you can hit while following the tutorials, and what each one looks
 
 **Symptom.** `a9s create cluster klutch control-plane` sits without visible progress during the Cognito step. The step is documented as taking about 20 minutes; it runs well past that.
 
-**Cause.** The IPv6 endpoint for AWS Cognito is sometimes very slow to respond — minutes per call — while the IPv4 endpoint answers immediately. The Cognito setup can add up to **35 minutes** to control plane creation as a result.
+**Cause.** The IPv6 endpoint for AWS Cognito is sometimes very slow to respond, taking minutes per call, while the IPv4 endpoint answers immediately. The Cognito setup can add up to **35 minutes** to control plane creation as a result.
 
 **What to do.** Temporarily disable IPv6 resolution before running the step. On macOS:
 
@@ -34,7 +34,7 @@ Re-enable it afterwards:
 networksetup -setv6automatic Wi-Fi
 ```
 
-The command is not stuck and does not need interrupting — it is waiting on Cognito.
+The command is not stuck and does not need interrupting. It is waiting on Cognito.
 
 ## Hosted zone never becomes resolvable
 
@@ -44,7 +44,7 @@ The command is not stuck and does not need interrupting — it is waiting on Cog
 
 **What to do.** Add an `NS` record to the parent zone, in the account that holds it, with the child zone's name as the record name and the printed name servers as the value. The CLI polls for up to 30 minutes and continues on its own once the delegation resolves.
 
-Deleting such a zone later is also manual — see the warning on the teardown step of the AWS tutorial.
+Deleting such a zone later is also manual. See the warning on the teardown step of the AWS tutorial.
 
 ## Commands act on the wrong cluster
 
@@ -79,6 +79,6 @@ Remember that Klutch resource kinds only exist in a **Workload** cluster after i
 
 **Symptom.** A PostgreSQL instance, Service Binding, Backup, or Restore in the Workload cluster reports `READY`, but connecting or using it fails.
 
-**Cause.** `READY` on these objects reflects whether the konnector propagated them to the Control Plane — not whether the underlying resource is usable.
+**Cause.** `READY` on these objects reflects whether the konnector propagated them to the Control Plane, not whether the underlying resource is usable.
 
 **What to do.** Read `.status.managed` instead. See [`READY` versus `.status.managed`](./concepts/index.md) in Concepts for the full explanation and the exact command.


### PR DESCRIPTION
Phase 2 of the documentation restructure tracked as [KLT-1084](https://anynines.atlassian.net/browse/KLT-1084). This story is [KLT-1086](https://anynines.atlassian.net/browse/KLT-1086).

## Why

Two of the four Diátaxis modes were missing from these docs.

There was **no explanation layer**. Tenant, Control Plane versus Workload cluster, bind, konnector and Crossplane claim all appeared first as command arguments, with no page defining them. The AWS quickstart explains Tenant well, 200 lines after a reader needed it.

There was **nowhere to land when things go wrong**. Three real operational hazards were documented only as prose scattered through one tutorial: a Cognito failure mode that can add 35 minutes to a step advertised as 20, cross-account hosted-zone delegation requiring manual NS records, and a known issue where backup data is not deleted from Minio. A reader who arrives at the reference instead of the tutorial hits all three blind.

## What this adds

**`docs/docs/concepts/index.md`** defines every term the tutorials use as a command argument, and separates the two PostgreSQL mechanisms whose object kinds look alike but are not interchangeable. It becomes the canonical explanation of `READY` versus `.status.managed`.

**`docs/docs/troubleshooting.md`** carries the three known hazards plus wrong-kube-context symptoms, each as symptom / cause / what to do.

Both files are new. No existing file is modified.

## The `READY` trap, captured rather than asserted

`.status.managed` is the field that decides whether a reader can tell success from failure at four separate tutorial steps. The page now shows it happening, captured from a local Klutch kind stack with a bound app cluster and a real `PostgresqlInstance` claim.

Ten seconds after creation:

```
NAME                    SYNCED   READY   CONNECTION-SECRET   AGE
my-klutch-pg-instance   True     True                        10s
```
```json
{"clusterStatus":"Pending"}
```

Two minutes later:

```json
{"clusterStatus":"Running","readyReplicas":1}
```

`READY` never changed. That is a sharper illustration than a healthy payload alone: the failure mode is not that `READY` is missing, it is that `READY` is already true and means something else.

## Terminology

Uses **Workload cluster** and **Control Plane**, matching the CLI's own command names and the existing docs. klutchio's `CONCEPTS.md` calls the same thing an **app cluster**; that synonym is noted once so readers moving between the two projects are not stranded.

## Verification

Docs build green. Both routes emit (`/develop/concepts/`, `/develop/troubleshooting/`). The cross-link from troubleshooting into concepts resolves. Neither new file contains a `TODO` or a literal alert tag.

No CI runs on this PR. The repository has no `pull_request` workflow at all -- `releasing.yaml` fires on version tags and `staging_cd.yaml` on pushes to `staging`, so docs are only built after merge. The first PR-triggered workflow arrives with #68; once that merges, this branch needs a rebase or an empty push to pick it up.

Merge-tested against [#68](https://github.com/anynines/a9s-cli-v2/pull/68) (KLT-1085) in a scratch worktree: file sets are disjoint, both merge orders apply cleanly, and the combined tree builds with both features intact. **Neither PR depends on the other; merge in whatever order review completes.**

## Sidebar ordering

Setting `sidebar_position` on only the two new pages turned out to be worse than setting none. Docusaurus sorts positioned items ahead of unpositioned ones, so `5` still beat the two sections that declared nothing and Troubleshooting landed second, with the intended "ends with troubleshooting" ordering never taking effect.

All three sections now carry an explicit `_category_.json` position, producing **Concepts, Hands-On Tutorials, a9s CLI Reference, Troubleshooting**. Verified through the built pagination links: concepts advances to hands-on-tutorials, and troubleshooting has no successor.

This takes a small part of U7's navigation work early, since the defect came from U5 and U6 rather than from waiting on it. KLT-1087 has correspondingly less to do.

## Scope notes

**The AWS quickstart is deliberately untouched.** The plan's U5 says to move the Tenant explanation out of it, but that file is rewritten by #68 and again by U9. Editing it here would buy a merge conflict and nothing else. Concepts now holds the canonical copy; U9 removes the inline one.

**A plan-level circular dependency was broken.** U6 declared a dependency on U8, and U8 on U5 and U6, with U8 belonging to a later story. Troubleshooting entries therefore carry symptom and cause without linking to the not-yet-existing recovery recipe; that link arrives with U8.

## Known residuals

- `servicebindings` has no captured payload; only `postgresqlinstances` was bound during capture. The page states that the field applies to the other kinds with different keys rather than inventing their shapes.


[KLT-1084]: https://anynines.atlassian.net/browse/KLT-1084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KLT-1086]: https://anynines.atlassian.net/browse/KLT-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ